### PR TITLE
Upgrade amqprs to 2.1 and deapool to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["network-programming", "asynchronous"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amqprs = { version = "1.0", default-features = false }
-deadpool = { version = "0.10", default-features = false, features = ["managed", "rt_tokio_1"] }
+amqprs = { version = "2.1", default-features = false }
+deadpool = { version = "0.12", default-features = false, features = ["managed", "rt_tokio_1"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ pub mod config;
 
 pub use amqprs;
 use amqprs::connection::OpenConnectionArguments;
+use deadpool::managed;
 pub use deadpool::managed::reexports::*;
 use deadpool::managed::{RecycleError, RecycleResult};
-use deadpool::{async_trait, managed};
 
 pub use config::{Config, ConfigError};
 
@@ -52,7 +52,6 @@ impl std::fmt::Debug for Manager {
     }
 }
 
-#[async_trait]
 impl managed::Manager for Manager {
     /// Type of [`Object`]s that this [`Manager`] creates and recycles.
     type Type = amqprs::connection::Connection;
@@ -62,7 +61,7 @@ impl managed::Manager for Manager {
 
     /// Creates a new instance of [`Manager::Type`].
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        Ok(Self::Type::open(&self.con_args).await?)
+        Self::Type::open(&self.con_args).await
     }
 
     /// Tries to recycle an instance of [`Manager::Type`].
@@ -74,7 +73,7 @@ impl managed::Manager for Manager {
         if conn.is_open() {
             Ok(())
         } else {
-            Err(RecycleError::StaticMessage("Connection closed."))
+            Err(RecycleError::message("Connection closed."))
         }
     }
 }


### PR DESCRIPTION
Deadpool no longer uses [async_trait](https://crates.io/crates/async-trait), minor modifications were necessary. No breaking changes.