### PR TITLE
Implement RecyclingMethod to Optionally Verify Connections

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,41 @@ use deadpool::Runtime;
 
 use crate::{Manager, Pool, PoolBuilder, PoolConfig};
 
+/// Possible methods of how a connection is recycled.
+///
+/// The default is [`Fast`] which does not check the connection health or
+/// perform any verification.
+///
+/// [`Fast`]: RecyclingMethod::Fast
+/// [`Verified`]: RecyclingMethod::Verified
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecyclingMethod {
+    /// Only run [`Connection::is_open()`][1] when recycling existing connections.
+    ///
+    /// Unless you have special needs this is a safe choice.
+    ///
+    /// [1]: amqprs::connection::Connection::is_open
+    Fast,
+
+    /// Run [`Connection::is_open()`][1] and execute a test query.
+    ///
+    /// This is slower, but guarantees that the rabbitmq connection is ready to
+    /// be used. Normally, [`Connection::is_open()`][1] should be enough to filter
+    /// out bad connections, but under some circumstances (i.e. hard-closed
+    /// network connections) it's possible that [`Connection::is_open()`][1]
+    /// returns `false` while the connection is dead. You will receive an error
+    /// on your first query then.
+    ///
+    /// [1]: amqprs::connection::Connection::is_open
+    Verified,
+}
+
+impl Default for RecyclingMethod {
+    fn default() -> Self {
+        Self::Fast
+    }
+}
+
 /// Configuration object.
 ///
 /// # Example
@@ -25,15 +60,25 @@ pub struct Config {
     pub con_args: OpenConnectionArguments,
     /// The [`PoolConfig`] passed to deadpool.
     pub pool_config: Option<PoolConfig>,
+
+    pub recycling_method: RecyclingMethod,
 }
 
 impl Config {
     /// Creates a new config with [`OpenConnectionArguments`] and optionally [`PoolConfig`].
     #[must_use]
-    pub const fn new(con_args: OpenConnectionArguments, pool_config: Option<PoolConfig>) -> Self {
+    pub const fn new(
+        con_args: OpenConnectionArguments,
+        pool_config: Option<PoolConfig>,
+        recycling_method: Option<RecyclingMethod>,
+    ) -> Self {
         Self {
             con_args,
             pool_config,
+            recycling_method: match recycling_method {
+                Some(method) => method,
+                None => RecyclingMethod::Fast,
+            },
         }
     }
 
@@ -43,6 +88,7 @@ impl Config {
         Self {
             con_args,
             pool_config: None,
+            recycling_method: RecyclingMethod::Fast,
         }
     }
 
@@ -66,9 +112,12 @@ impl Config {
     /// Unlike other `deadpool-*` libs, `deadpool-amqprs` does not require user to pass [`deadpool::Runtime`],
     /// because amqprs is built on top of `tokio`, meaning one can only use `tokio` with it.
     pub fn builder(&self) -> PoolBuilder {
-        Pool::builder(Manager::new(self.con_args.clone()))
-            .config(self.pool_config.unwrap_or_default())
-            .runtime(Runtime::Tokio1)
+        Pool::builder(Manager::new(
+            self.con_args.clone(),
+            self.recycling_method.clone(),
+        ))
+        .config(self.pool_config.unwrap_or_default())
+        .runtime(Runtime::Tokio1)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod config;
 
-pub use amqprs;
+//use amqprs;
 use amqprs::connection::OpenConnectionArguments;
 use config::RecyclingMethod;
 use deadpool::managed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,15 +75,16 @@ impl managed::Manager for Manager {
     ///
     /// Returns [`Manager::Error`] if the instance couldn't be recycled.
     async fn recycle(&self, conn: &mut Self::Type, _: &Metrics) -> RecycleResult<Self::Error> {
-        if conn.is_open() {
-            if self.recycling_method == RecyclingMethod::Verified
-                && conn.open_channel(None).await.is_err()
-            {
-                return Err(RecycleError::message("Connection closed."));
-            }
-            Ok(())
-        } else {
-            Err(RecycleError::message("Connection closed."))
+        if !conn.is_open() {
+            return Err(RecycleError::message("Connection closed."));
         }
+
+        if self.recycling_method == RecyclingMethod::Verified
+            && conn.open_channel(None).await.is_err()
+        {
+            return Err(RecycleError::message("Connection closed."));
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Overview

This pull request introduces **RecyclingMethod** which allows the user to optionally verify connections before they are reused from the pool. This feature helps ensure that stale or broken connections are not inadvertently recycled, leading to a more robust and stable connection handling mechanism.

### Changes Made

- **RecyclingMethod Implementation:**  
  Adds a method to optionally verify connection health prior to reuse. This allows users to configure connection recycling based on their application's requirements.

### Motivation and Context

In real-world scenarios, connections may become stale or drop unexpectedly. By verifying connections before reusing them, this feature minimizes errors due to invalid connections. The optional nature of the verification lets developers choose to enable this feature as needed, balancing reliability and performance.

### Conclusion

This PR enhances connection reliability and overall pool stability by introducing an optional connection verification mechanism. Feedback and further suggestions are welcome.


--- 
As you may have noticed, these commits are from several months ago. I just realized I never made a PR for these and have been using my branch in production for the last 7 months.
